### PR TITLE
feat(CAT-36): add styles for game start screen controls

### DIFF
--- a/packages/client/src/components/game/game-start-screen/game-start-screen.css
+++ b/packages/client/src/components/game/game-start-screen/game-start-screen.css
@@ -1,0 +1,18 @@
+.game-start-screen__select {
+  display: block;
+  margin-bottom: 20px;
+}
+
+.game-start-screen__button {
+  width: 100%;
+  background-color: var(--dark);
+  color: var(--light);
+  font-size: 22px;
+  padding-top: 2px;
+}
+
+.game-start-screen .ant-btn.game-start-screen__button:hover {
+  background-color: var(--dark);
+  color: var(--light);
+  opacity: 0.8;
+}

--- a/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
+++ b/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
@@ -1,5 +1,8 @@
+import { Button, ConfigProvider, Select } from 'antd';
+import { Color } from '@/helpers/constants/global';
 import { Difficulty } from '@/components/game/types';
 import React from 'react';
+import './game-start-screen.css';
 
 interface GameStartScreenProps {
   selectedDifficulty: Difficulty;
@@ -13,15 +16,39 @@ export const GameStartScreen: React.FC<GameStartScreenProps> = ({
   onDifficultyChange,
 }) => {
   return (
-    <div>
-      <h2>Choose Difficulty:</h2>
-      <select
-        value={selectedDifficulty}
-        onChange={e => onDifficultyChange(e.target.value as Difficulty)}>
-        <option value={Difficulty.EASY}>Easy</option>
-        <option value={Difficulty.HARD}>Hard</option>
-      </select>
-      <button onClick={onStartGame}>Start Game</button>
+    <div className='game-start-screen'>
+      <h2>Выберите уровень сложности:</h2>
+      <ConfigProvider
+        theme={{
+          token: {
+            colorPrimary: Color.Dark,
+            colorBorder: Color.Dark,
+            colorText: Color.Dark,
+          },
+          components: {
+            Select: {
+              selectorBg: 'transparent',
+              optionSelectedBg: Color.Light,
+            },
+          },
+        }}>
+        <Select
+          className='game-start-screen__select'
+          defaultValue={selectedDifficulty}
+          options={[
+            { value: Difficulty.EASY, label: <span>Лёгкий</span> },
+            { value: Difficulty.HARD, label: <span>Хардкор</span> },
+          ]}
+          onChange={(value: Difficulty) => onDifficultyChange(value)}
+        />
+      </ConfigProvider>
+      <Button
+        type='primary'
+        size='large'
+        className='game-start-screen__button'
+        onClick={onStartGame}>
+        Начать игру
+      </Button>
     </div>
   );
 };

--- a/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
+++ b/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
@@ -39,7 +39,7 @@ export const GameStartScreen: React.FC<GameStartScreenProps> = ({
             { value: Difficulty.EASY, label: <span>Лёгкий</span> },
             { value: Difficulty.HARD, label: <span>Хардкор</span> },
           ]}
-          onChange={(value: Difficulty) => onDifficultyChange(value)}
+          onChange={onDifficultyChange}
         />
       </ConfigProvider>
       <Button

--- a/packages/client/src/pages/game-page/game-page.test.tsx
+++ b/packages/client/src/pages/game-page/game-page.test.tsx
@@ -6,13 +6,13 @@ import '@testing-library/jest-dom';
 describe('Тестируем страницу GamePage в обход Auth Route HOC.', () => {
   test('проверяем рендер основного состояния страницы GameStartScreen с выбором уровня сложности', async () => {
     const { getByText } = render(<GamePage />);
-    const chooseDifficultyElement = getByText(/Choose Difficulty/i);
+    const chooseDifficultyElement = getByText(/Выберите уровень сложности/i);
     expect(chooseDifficultyElement).toBeInTheDocument();
   });
 
   test('проверяем отображение экрана начала игры после нажатия на кнопку "Start Game" на странице', async () => {
     const { getByText, container } = render(<GamePage />);
-    const startGameButton = getByText('Start Game');
+    const startGameButton = getByText('Начать игру');
     fireEvent.click(startGameButton);
 
     await waitFor(() => {


### PR DESCRIPTION
### Какую задачу решаем
[Стилизовать контролы на экране начала игры](https://linear.app/cat-coders/issue/CAT-36/stilizovat-kontroly-v-igre)
Также изменил язык интерфейса на русский, как во всех остальных частях приложения.

### Скриншоты
![image](https://github.com/VicDoom/cat-pairs/assets/10059268/081d7d3e-0ee8-4c68-a04a-9243409f3f47)
![image](https://github.com/VicDoom/cat-pairs/assets/10059268/ce680e88-f917-4948-8fc4-c9295c8aa5dd)