### PR TITLE
CAT-61 [баг с двойным вызовом gameApi в development]

### DIFF
--- a/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
+++ b/packages/client/src/components/game/game-start-screen/game-start-screen.tsx
@@ -96,6 +96,7 @@ export const GameStartScreen: React.FC<GameStartScreenProps> = ({
           block
           darkTheme={theme !== Theme.Dark}
           onClick={handleResetGame}
+          style={{ marginTop: '15px' }}
           label={'Начать заново'}
         />
       )}

--- a/packages/client/src/components/game/game.tsx
+++ b/packages/client/src/components/game/game.tsx
@@ -30,8 +30,10 @@ export const Game: React.FC<GameProps> = ({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isGameReset, setIsGameReset] = useState<boolean>(false);
   const navigate = useNavigate();
+  const initialized = useRef(false);
 
   useEffect(() => {
+    if (initialized.current) return;
     const gameApi = new GameApi(
       gameRef,
       canvasRef,
@@ -42,6 +44,9 @@ export const Game: React.FC<GameProps> = ({
     );
     gameApi.render();
     setGame(gameApi);
+    return () => {
+      initialized.current = true;
+    };
   }, [changeGameStatus, gameStatus, selectedDifficulty]);
 
   if (!game) return <div style={{ color: 'white' }}>Loading...</div>;


### PR DESCRIPTION
### Какую задачу решаем
Исправить баг. Не кликаются карточки в development (strict mode)

Проверил в сборке контейнера и локальном окружении. Все ок. 